### PR TITLE
Change Jolokia agent path

### DIFF
--- a/intg_test_manager.py
+++ b/intg_test_manager.py
@@ -649,7 +649,7 @@ def attach_jolokia_agent(spath):
         sp = sp + ".sh"
         if Path.exists(Path(sp)):
             jolokia_agent = \
-                "    -javaagent:/opt/wso2/jolokia-jvm-1.6.0-agent.jar=port=8778,host=localhost,protocol=http \\\n"
+                "    -javaagent:/opt/testgrid/jolokia.jar=port=8778,host=localhost,protocol=http \\\n"
             with open(sp, "r") as in_file:
                 buf = in_file.readlines()
             with open(sp, "w") as out_file:


### PR DESCRIPTION
To change Jolokia agent path. (All the resources are moved to /opt/testgrid directory)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes