### PR TITLE
Fix typeerror in get latest stable artifacts

### DIFF
--- a/intg_test_manager.py
+++ b/intg_test_manager.py
@@ -602,7 +602,7 @@ def get_latest_stable_dist():
     """Download the latest stable distribution
     """
     build_num_artifact = get_latest_stable_artifacts_api()
-    build_num_artifact = re.sub(r'http.//(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):(\d{1,5})', "https://wso2.org", build_num_artifact)
+    build_num_artifact = re.sub(r'http.//(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):(\d{1,5})', "https://wso2.org", str(build_num_artifact))
     if build_num_artifact is None:
         raise Exception("Error occured while getting latest stable build artifact API path")
     relative_path = get_relative_path_of_dist_storage(build_num_artifact + "api/xml")


### PR DESCRIPTION
## Purpose
Typeerror issue occured when building EI integration test. This PR includes the fix for that. 
Issue - https://testgrid-live.private.wso2.com/admin/blue/organizations/jenkins/RELEASES%2Fintg-test-wso2ei-master/detail/intg-test-wso2ei-master/18/pipeline/191

## Approach
Issue - `TypeError: expected string or bytes-like object`
Approach - Change the `build_num_artifact` into strings before passing it to _re.sub_

## User stories
https://github.com/wso2/product-ei/issues/3433
