### PR TITLE
Add error handling if no new updated product is found in UAT. 

### DIFF
--- a/get-wum-uat-products.sh
+++ b/get-wum-uat-products.sh
@@ -28,7 +28,6 @@ JOB_LIST=${JOB_LIST}
 PRODUCT_ID=${PRODUCT_ID}
 PRODUCT_ID_LIST=${PRODUCT_ID_LIST}
 
-
 #Generating access token for WUM Live environment to get the latest live synced timestamp
 createAccessTokenLive() {
 	echo "Generating Access Token for Live"
@@ -63,8 +62,9 @@ getTimestampLive() {
     curl -s -X GET -H "${HEADER_ACCEPT}" -H "Authorization:Bearer ${live_access_token}" "${uri}" --output "${RESPONSE_TIMESTAMP}"
     #get only the timestamp value from the json response
     live_timestamp=$( jq -r ".timestamp" $RESPONSE_TIMESTAMP )
+
+		# stdout live timestamp will be retrieved from WUMUpdateVerifier.groovy
 		echo $live_timestamp
-		#echo "Live timestamp: $live_timestamp"
 }
 
 #Get timestamp by calling to WUM UAT environment to get the latest live synced timestamp
@@ -75,8 +75,9 @@ getTimestampUAT() {
     curl -s -X GET -H "${HEADER_ACCEPT}" -H "Authorization:Bearer ${uat_access_token}" "${uri}" --output "${RESPONSE_TIMESTAMP}"
     #get only the timestamp value from the json response
     uat_timestamp=$( jq -r ".timestamp" $RESPONSE_TIMESTAMP )
+
+		# stdout uat timestamp will be retrieved from WUMUpdateVerifier.groovy
 		echo $uat_timestamp
-		#echo "UAT timestamp: $uat_timestamp"
 }
 
 #Get the product list in WUM UAT environment
@@ -104,7 +105,7 @@ getProductList() {
 	   echo "There are WUM updated product packs in UAT."
 	else
   	  echo "There is/are no updated product packs for the given timestamp in UAT. Hence Skipping the process."
-  	  exit 0 #TO DO: error handling here ... check for updates before trigering the build.
+  	  exit 0
 	fi
 }
 
@@ -163,22 +164,31 @@ getProductIdList(){
 
 args=$1
 
-case $args in
-	--get-live-timestamp)
-		createAccessTokenLive
-		getTimestampLive
-		;;
-	--get-uat-timestamp)
-		createAccessTokenUAT
-		getTimestampUAT
-		;;
- 	--get-job-list)
-		live_timestamp=$2
-		createAccessTokenUAT
-		getProductList
-		getChannelList
-		getProductIdList
-		;;
-	*)
-		echo "Invalid argument. Please try again."
-esac
+if [[ -z $args ]]; then
+	createAccessTokenLive
+	createAccessTokenUAT
+	getTimestampLive
+	getProductList
+	getChannelList
+	getProductIdList
+else
+	case $args in
+		--get-live-timestamp)
+			createAccessTokenLive
+			getTimestampLive
+			;;
+		--get-uat-timestamp)
+			createAccessTokenUAT
+			getTimestampUAT
+			;;
+	 	--get-job-list)
+			live_timestamp=$2
+			createAccessTokenUAT
+			getProductList
+			getChannelList
+			getProductIdList
+			;;
+		*)
+			echo "Invalid argument. Please try again."
+	esac
+fi

--- a/get-wum-uat-products.sh
+++ b/get-wum-uat-products.sh
@@ -69,7 +69,7 @@ getTimestampLive() {
 #Get timestamp by calling to WUM UAT environment to get the latest live synced timestamp
 getTimestampUAT() {
 	echo "GET Timestamp in UAT"
-    uri="https://api.updates.wso2.com/t/wso2umuat/updates/3.0.0/timestamps/latest"
+    uri="https://gateway.api.cloud.wso2.com/t/wso2umuat/updates/3.0.0/timestamps/latest"
     #echo "Calling URI (GET): " ${uri}
     curl -s -X GET -H "${HEADER_ACCEPT}" -H "Authorization:Bearer ${uat_access_token}" "${uri}" --output "${RESPONSE_TIMESTAMP}"
     #get only the timestamp value from the json response

--- a/get-wum-uat-products.sh
+++ b/get-wum-uat-products.sh
@@ -62,6 +62,20 @@ getTimestampLive() {
     curl -s -X GET -H "${HEADER_ACCEPT}" -H "Authorization:Bearer ${live_access_token}" "${uri}" --output "${RESPONSE_TIMESTAMP}"
     #get only the timestamp value from the json response
     live_timestamp=$( jq -r ".timestamp" $RESPONSE_TIMESTAMP )
+
+		echo "Live timestamp: $live_timestamp"
+}
+
+#Get timestamp by calling to WUM UAT environment to get the latest live synced timestamp
+getTimestampUAT() {
+	echo "GET Timestamp in UAT"
+    uri="https://api.updates.wso2.com/t/wso2umuat/updates/3.0.0/timestamps/latest"
+    #echo "Calling URI (GET): " ${uri}
+    curl -s -X GET -H "${HEADER_ACCEPT}" -H "Authorization:Bearer ${uat_access_token}" "${uri}" --output "${RESPONSE_TIMESTAMP}"
+    #get only the timestamp value from the json response
+    uat_timestamp=$( jq -r ".timestamp" $RESPONSE_TIMESTAMP )
+
+		echo "UAT timestamp: $uat_timestamp"
 }
 
 #Get the product list in WUM UAT environment
@@ -89,7 +103,7 @@ getProductList() {
 	   echo "There are WUM updated product packs in UAT."
 	else
   	  echo "There is/are no updated product packs for the given timestamp in UAT. Hence Skipping the process."
-  	  exit 0
+  	  exit 0 #TO DO: error handling here ... check for updates before trigering the build.
 	fi
 }
 

--- a/get-wum-uat-products.sh
+++ b/get-wum-uat-products.sh
@@ -162,10 +162,10 @@ getProductIdList(){
 
 getUpdateStatus(){
 	#generate access token for Live and UAT
-	$(createAccessTokenLive); $(createAccessTokenUAT)
+	createAccessTokenLive; createAccessTokenUAT
 
 	#get the latest timestamps in Live and UAT
-	$(getTimestampLive); $(getTimestampUAT)
+	getTimestampLive; getTimestampUAT
 
 	if [ ${live_timestamp} -eq ${uat_timestamp} ]; then
 		return 0;

--- a/get-wum-uat-products.sh
+++ b/get-wum-uat-products.sh
@@ -63,7 +63,7 @@ getTimestampLive() {
     #get only the timestamp value from the json response
     live_timestamp=$( jq -r ".timestamp" $RESPONSE_TIMESTAMP )
 
-		echo "Live timestamp: $live_timestamp"
+		#echo "Live timestamp: $live_timestamp"
 }
 
 #Get timestamp by calling to WUM UAT environment to get the latest live synced timestamp
@@ -75,7 +75,7 @@ getTimestampUAT() {
     #get only the timestamp value from the json response
     uat_timestamp=$( jq -r ".timestamp" $RESPONSE_TIMESTAMP )
 
-		echo "UAT timestamp: $uat_timestamp"
+		#echo "UAT timestamp: $uat_timestamp"
 }
 
 #Get the product list in WUM UAT environment
@@ -160,10 +160,38 @@ getProductIdList(){
 
 }
 
-createAccessTokenLive
-createAccessTokenUAT
-getTimestampLive
-getTimestampUAT
-getProductList
-getChannelList
-getProductIdList
+getUpdateStatus(){
+	#generate access token for Live and UAT
+	$(createAccessTokenLive); $(createAccessTokenUAT)
+
+	#get the latest timestamps in Live and UAT
+	$(getTimestampLive); $(getTimestampUAT)
+
+	if [ ${live_timestamp} -eq ${uat_timestamp} ]; then
+		return 0;
+	fi
+}
+
+getJobList(){
+	#get products with newest UAT updates.
+	$(getProductList)
+
+	#get channel list for each product
+ 	$(getChannelList)
+
+	#get Id for each product
+	$(getProductIdList)
+}
+
+args=$1
+
+case $args in
+	--check-update-status)
+		getUpdateStatus
+		;;
+ 	--get-job-list)
+		getJobList
+		;;
+	*)
+		echo "Invalid argument. Please try again."
+esac

--- a/get-wum-uat-products.sh
+++ b/get-wum-uat-products.sh
@@ -28,6 +28,7 @@ JOB_LIST=${JOB_LIST}
 PRODUCT_ID=${PRODUCT_ID}
 PRODUCT_ID_LIST=${PRODUCT_ID_LIST}
 
+
 #Generating access token for WUM Live environment to get the latest live synced timestamp
 createAccessTokenLive() {
 	echo "Generating Access Token for Live"
@@ -62,7 +63,7 @@ getTimestampLive() {
     curl -s -X GET -H "${HEADER_ACCEPT}" -H "Authorization:Bearer ${live_access_token}" "${uri}" --output "${RESPONSE_TIMESTAMP}"
     #get only the timestamp value from the json response
     live_timestamp=$( jq -r ".timestamp" $RESPONSE_TIMESTAMP )
-
+		echo $live_timestamp
 		#echo "Live timestamp: $live_timestamp"
 }
 
@@ -74,7 +75,7 @@ getTimestampUAT() {
     curl -s -X GET -H "${HEADER_ACCEPT}" -H "Authorization:Bearer ${uat_access_token}" "${uri}" --output "${RESPONSE_TIMESTAMP}"
     #get only the timestamp value from the json response
     uat_timestamp=$( jq -r ".timestamp" $RESPONSE_TIMESTAMP )
-
+		echo $uat_timestamp
 		#echo "UAT timestamp: $uat_timestamp"
 }
 
@@ -160,37 +161,23 @@ getProductIdList(){
 
 }
 
-getUpdateStatus(){
-	#generate access token for Live and UAT
-	createAccessTokenLive; createAccessTokenUAT
-
-	#get the latest timestamps in Live and UAT
-	getTimestampLive; getTimestampUAT
-
-	if [ ${live_timestamp} -eq ${uat_timestamp} ]; then
-		return 0;
-	fi
-}
-
-getJobList(){
-	#get products with newest UAT updates.
-	$(getProductList)
-
-	#get channel list for each product
- 	$(getChannelList)
-
-	#get Id for each product
-	$(getProductIdList)
-}
-
 args=$1
 
 case $args in
-	--check-update-status)
-		getUpdateStatus
+	--get-live-timestamp)
+		createAccessTokenLive
+		getTimestampLive
+		;;
+	--get-uat-timestamp)
+		createAccessTokenUAT
+		getTimestampUAT
 		;;
  	--get-job-list)
-		getJobList
+		live_timestamp=$2
+		createAccessTokenUAT
+		getProductList
+		getChannelList
+		getProductIdList
 		;;
 	*)
 		echo "Invalid argument. Please try again."


### PR DESCRIPTION
## Purpose
> Exit 0 from the script if no UAT update is found for a specific timestamp is not handled through Jenkins pipeline [WUMUpdateVerifier.groovy](https://github.com/NishikaDeSilva/testgrid-jenkins-library/blob/dev/vars/WUMUpdateVerifier.groovy)

## Goals
> Alter the [get-wum-uat-products.sh](https://github.com/wso2-incubator/test-integration-tests-runner/blob/master/get-wum-uat-products.sh) to handle the said purpose.

## Approach
> If no argument is found the script will execute as per earlier.
> Arguments were added so that when running from the pipeline, the UAT can be checked for new updates. 